### PR TITLE
add Flash to Whisper

### DIFF
--- a/Whisper/Entity.php
+++ b/Whisper/Entity.php
@@ -137,3 +137,43 @@ function whisper_drain_end() {
 
 /* IMBUE
  * todo set default variable to text */
+
+/* FLASH
+ * todo set default variable to text */
+
+#NOTE: init flash, reset pointer, start buffer
+function whisper_flash_start() {
+    global $CHANTER_FLASH_POINT;
+    
+    $CHANTER_FLASH_POINT = 0;
+    ob_start();
+}
+
+#NOTE: run one flash step, update pointer, flush output
+function whisper_flash_run() {
+    global $CHANTER_FLASH_POINT;
+    
+    if (aether_has_entity('whisper')) {
+        whisper_echo("\r");
+        whisper_echo(str_repeat("{{color-warning}}/", $CHANTER_FLASH_POINT));
+        whisper_echo(str_repeat("{{color-secondary}}/", 50 - $CHANTER_FLASH_POINT));
+    }
+
+    if ($CHANTER_FLASH_POINT == 50) {
+        $CHANTER_FLASH_POINT = 0;
+    }
+
+    $CHANTER_FLASH_POINT += 1;
+
+    flush();
+    ob_flush();
+}
+
+#NOTE: stop flash, end buffer, add newline
+function whisper_flash_stop() {
+    @ob_end_flush();
+    
+    if (aether_has_entity('whisper')) {
+      whisper_echo("\n");
+    }
+}

--- a/Whisper/Essence.php
+++ b/Whisper/Essence.php
@@ -88,3 +88,6 @@ $GLOBALS['WHISPER_DRAIN'] = [];
 
 #NOTE: State toggle to determine whether whisper is in drain mode
 $GLOBALS['WHISPER_DRAIN_STATE'] = false;
+
+#NOTE: global pointer for flash progress
+$GLOBAL['CHANTER_FLASH_POINT'] = 0;

--- a/Whisper/Manifest.php
+++ b/Whisper/Manifest.php
@@ -77,4 +77,27 @@ class Manifest extends \Rune\Manifest {
     return self::class;
   }
 
+  #NOTE: wrapper to control flash with callbacks
+  public static function flash( Callable $execute ) {
+    whisper_flash_start();
+    
+    #NOTE: define helpers for continue, stop, animation
+    $continue = fn() => whisper_flash_start();
+    $stop = fn() => whisper_flash_stop();
+    $animation = fn() => whisper_flash_run();
+    
+    #NOTE: run user callback with helpers
+    $return = $execute( 
+        animation: $animation, 
+        stop: $stop, 
+        continue: $continue
+    );
+
+    #NOTE: finalize flash
+    whisper_flash_stop();
+    aether_arcane('Whisper.manifest.clear');
+
+    return $return;
+  }
+
 }

--- a/Whisper/Phantasm.php
+++ b/Whisper/Phantasm.php
@@ -6,7 +6,7 @@ class Phantasm extends \Rune\Phantasm {
 
   public $origin = __DIR__;
 
-  public $version = '1.11';
+  public $version = '1.12';
   
   public $main = 'Whisper';
 


### PR DESCRIPTION
loop-based progress animation in console to indicate an ongoing process, instead of staying silent.
can use in loops, infinite-loops, background processes, or even async contexts.

#### Modified
- Essence: global state for flash pointer point.
- Entity: functional units whisper_flash_start, whisper_flash_run, and whisper_flash_stop.
- Manifest: Whisper::flash static class wrapper for easier developer usage.

#### Casting
```php
Chanter::cast('flash', function() {
  Whisper::flash(
    execute:function($continue, $stop, $animation) {
      for ($i = 0; $i < 1000; $i++) {
        if ($i == 900) {
          $stop();
          Whisper::echo("OUTPUT");
          break;
        } else {
          $animation();
        }
      }
    }
  );
});

```